### PR TITLE
Fix onboarding screenshot layout after real-app render

### DIFF
--- a/Glide/AppDelegate.swift
+++ b/Glide/AppDelegate.swift
@@ -604,8 +604,10 @@ extension AppDelegate {
     /// When launched with `--screenshot`, render the requested SwiftUI views to PNG and
     /// terminate — without starting the status item, event taps, or onboarding. This is
     /// how `make screenshots` / CI produce pixel-accurate marketing images straight from
-    /// the real app views (correct system font, spacing, and assets). No-op when the flag
-    /// is absent. Called from applicationDidFinishLaunching so AppKit/NSApp are ready.
+    /// the real app views (correct system font, spacing, and assets). Output size follows
+    /// each view's natural `fittingSize` (e.g. OnboardingView minWidth 430 → 430×471).
+    /// When dimensions change, update `scripts/screenshot-layout.json` and the matching
+    /// `aspect-ratio` rules in `site/index.html`.
     ///
     /// Usage:
     ///   Glide --screenshot [--menu <out.png>] [--onboarding <out.png>] [--version x.y.z]

--- a/scripts/render-screenshots.sh
+++ b/scripts/render-screenshots.sh
@@ -74,8 +74,9 @@ root = Path(sys.argv[1])
 layout = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
 errors: list[str] = []
 
-for key in ("dropdown", "onboarding", "menubar"):
-    entry = layout[key]
+for key, entry in layout.items():
+    if not isinstance(entry, dict) or "width" not in entry or "height" not in entry:
+        continue
     width = int(entry["width"])
     height = int(entry["height"])
     paths = {entry.get("docs"), entry.get("site"), entry.get("output")}

--- a/scripts/render-screenshots.sh
+++ b/scripts/render-screenshots.sh
@@ -52,6 +52,56 @@ mod.composite_menubar(root / "site/drop-down.png", output)
 PY
 }
 
+# Fail fast when rendered PNG dimensions drift from scripts/screenshot-layout.json.
+# If OnboardingView or StatusMenuView layout changes, update the layout file and the
+# matching aspect-ratio rules in site/index.html (see siteCss hints in the layout).
+verify_screenshot_sizes() {
+	python3 - "$ROOT" "$LAYOUT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+try:
+    from PIL import Image
+except ImportError:
+    print(
+        "warning: Pillow not installed; skipping screenshot dimension verification",
+        file=sys.stderr,
+    )
+    raise SystemExit(0)
+
+root = Path(sys.argv[1])
+layout = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+errors: list[str] = []
+
+for key in ("dropdown", "onboarding", "menubar"):
+    entry = layout[key]
+    width = int(entry["width"])
+    height = int(entry["height"])
+    paths = {entry.get("docs"), entry.get("site"), entry.get("output")}
+    paths = sorted({p for p in paths if p})
+    for rel in paths:
+        path = root / rel
+        if not path.exists():
+            errors.append(f"{key}: missing {rel}")
+            continue
+        with Image.open(path) as img:
+            actual_w, actual_h = img.size
+        if actual_w != width or actual_h != height:
+            hint = entry.get("siteCss", "site/index.html aspect-ratio")
+            errors.append(
+                f"{key}: {rel} is {actual_w}x{actual_h}, expected {width}x{height} "
+                f"(update scripts/screenshot-layout.json and {hint})"
+            )
+
+if errors:
+    print("error: screenshot dimension drift detected:", file=sys.stderr)
+    for line in errors:
+        print(f"  - {line}", file=sys.stderr)
+    raise SystemExit(1)
+PY
+}
+
 VERSION="$(tr -d ' \n\r' < "$ROOT/VERSION")"
 VERSION="${VERSION#v}"
 
@@ -97,5 +147,7 @@ else
 	echo "-----------------------------------" >&2
 	python3 "$ROOT/scripts/patch-screenshot-version.py"
 fi
+
+verify_screenshot_sizes
 
 echo "Updated docs/drop-down.png, docs/onboarding.png, site/drop-down.png, site/onboarding.png, site/menubar.png"

--- a/scripts/screenshot-layout.json
+++ b/scripts/screenshot-layout.json
@@ -1,7 +1,23 @@
 {
+  "dropdown": {
+    "docs": "docs/drop-down.png",
+    "site": "site/drop-down.png",
+    "width": 240,
+    "height": 421
+  },
+  "onboarding": {
+    "docs": "docs/onboarding.png",
+    "site": "site/onboarding.png",
+    "width": 430,
+    "height": 471,
+    "siteCss": "site/index.html — .settings-section--onboarding .screenshot-card aspect-ratio"
+  },
   "menubar": {
     "base": "site/menubar-base.png",
     "output": "site/menubar.png",
+    "width": 687,
+    "height": 798,
+    "siteCss": "site/index.html — .settings-section .screenshot-card aspect-ratio",
     "card": {
       "x": 40,
       "y": 82,

--- a/site/index.html
+++ b/site/index.html
@@ -1004,7 +1004,6 @@
               <img
                 src="onboarding.png"
                 alt="Glide one-time accessibility setup"
-                class="onboarding-img"
                 loading="lazy"
               />
             </div>

--- a/site/index.html
+++ b/site/index.html
@@ -368,12 +368,16 @@
       .settings-section .screenshot-wrap:last-child {
         justify-content: flex-end;
       }
-      /* Wrap size matches onboarding.png (476×546) aspect ratio */
+      /* Menubar composite (site/menubar.png — see scripts/screenshot-layout.json) */
       .settings-section .screenshot-card {
         width: 350px;
         max-width: 100%;
         flex-shrink: 0;
-        aspect-ratio: 476/546;
+        aspect-ratio: 687 / 798;
+      }
+      /* Onboarding render (docs/onboarding.png — keep in sync with screenshot-layout.json) */
+      .settings-section--onboarding .screenshot-card {
+        aspect-ratio: 430 / 471;
       }
       .settings-section .screenshot-card img {
         width: 100%;
@@ -381,10 +385,6 @@
         display: block;
         object-fit: cover;
         object-position: center;
-      }
-      /* Zoom onboarding image to crop built-in padding */
-      .settings-section .screenshot-card img.onboarding-img {
-        transform: scale(1.12);
       }
       .settings-checklist {
         list-style: none;


### PR DESCRIPTION
## Summary
- Fix the broken onboarding section on the site after PR #33 changed `onboarding.png` from 476×546 (manual / ScreenshotRenderer) to 430×471 (real `--screenshot` render).
- Scope onboarding and menubar cards to their own `aspect-ratio` values and remove the `scale(1.12)` crop hack that only applied to the old padded captures.
- Add canonical screenshot dimensions to `scripts/screenshot-layout.json` and verify PNG sizes at the end of `make screenshots` so future view layout changes fail loudly instead of silently breaking the site.

## Test plan
- [ ] Open `site/index.html` and confirm the onboarding card shows the full dialog without awkward cropping or empty space.
- [ ] Confirm the menubar section still looks correct.
- [ ] Run `make screenshots` on macOS and confirm dimension verification passes.