### PR TITLE
Improve Makefile xcodebuild logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@
 #   run-debug               : Build and run the app (Debug, no provisioning profile)
 #   run-onboarding          : Build (Debug) and run with onboarding dialog
 #
+# xcodebuild output: indented dim log by default (-quiet). VERBOSE=true for full log.
+#
 # -----------------------------------------------------------------------------------------------------------
 
 # Default target
@@ -164,7 +166,7 @@ screenshots: ## Regenerate docs/ and site/ PNGs (drop-down, onboarding, menubar)
 build: ## Build (Release configuration)
 	@$(LOGGER) log_separator
 	@$(LOGGER) log_info "Building Glide"
-	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -configuration $(CONFIG) -destination '$(DEST)' -derivedDataPath "$(BUILD_OUTPUT_DIR)" build
+	@set -o pipefail; $(LOGGER) log_run_xcodebuild xcodebuild -project $(PROJECT) -scheme $(SCHEME) -configuration $(CONFIG) -destination '$(DEST)' -derivedDataPath "$(BUILD_OUTPUT_DIR)" build
 
 # -----------------------------------------------------------------------------------------------------------
 # Build (Debug configuration)
@@ -172,7 +174,7 @@ build: ## Build (Release configuration)
 build-debug: ## Build (Debug configuration)
 	@$(LOGGER) log_separator
 	@$(LOGGER) log_info "Building Glide (Debug configuration)"
-	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -configuration Debug -destination '$(DEST)' -derivedDataPath "$(BUILD_OUTPUT_DIR)" build
+	@set -o pipefail; $(LOGGER) log_run_xcodebuild xcodebuild -project $(PROJECT) -scheme $(SCHEME) -configuration Debug -destination '$(DEST)' -derivedDataPath "$(BUILD_OUTPUT_DIR)" build
 	@$(LOGGER) log_success "Build complete"
 
 # -----------------------------------------------------------------------------------------------------------
@@ -182,11 +184,11 @@ clean: ## Clean build artifacts
 	@$(LOGGER) log_separator
 	@$(LOGGER) log_info "Cleaning build artifacts"
 	@$(LOGGER) log_indent log_dim "Removing build output..."
-	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -configuration $(CONFIG) -destination '$(DEST)' -derivedDataPath "$(BUILD_OUTPUT_DIR)" clean
-	rm -rf "$(BUILD_OUTPUT_DIR)"
+	@set -o pipefail; $(LOGGER) log_run_xcodebuild xcodebuild -project $(PROJECT) -scheme $(SCHEME) -configuration $(CONFIG) -destination '$(DEST)' -derivedDataPath "$(BUILD_OUTPUT_DIR)" clean
+	@rm -rf "$(BUILD_OUTPUT_DIR)"
 	@$(LOGGER) log_indent log_dim "Removing DMG files..."
-	rm -f Glide-$(VERSION_DEV).dmg Glide-$(VERSION_RELEASE).dmg
-	rm -f rw.*.Glide-*.dmg
+	@rm -f Glide-$(VERSION_DEV).dmg Glide-$(VERSION_RELEASE).dmg
+	@rm -f rw.*.Glide-*.dmg
 	@$(LOGGER) log_success "Clean complete"
 
 # -----------------------------------------------------------------------------------------------------------
@@ -196,7 +198,7 @@ install: build ## Build and install to ~/Applications
 	@$(LOGGER) log_separator
 	@$(LOGGER) log_info "Installing Glide to /Applications"
 	@if [ -d "/Applications/Glide.app" ]; then \
-		printf "Glide is already installed in /Applications. Replace it? [y/N] "; \
+		printf "  Glide is already installed in /Applications. Replace it? [y/N] "; \
 		read answer; \
 		case $$answer in \
 			y|Y|yes|YES) \
@@ -205,7 +207,7 @@ install: build ## Build and install to ~/Applications
 				$(LOGGER) log_success "Installed Glide to /Applications/Glide.app"; \
 				;; \
 			*) \
-				$(LOGGER) log_dim "Install canceled."; \
+				$(LOGGER) log_warning "Install canceled."; \
 				;; \
 		esac; \
 	else \
@@ -397,5 +399,5 @@ run-onboarding: build-debug ## Build (Debug) and run Glide with onboarding dialo
 test: ## Run tests (Debug configuration)
 	@$(LOGGER) log_separator
 	@$(LOGGER) log_info "Running tests"
-	xcodebuild test -project $(PROJECT) -scheme $(SCHEME) -configuration Debug -destination '$(DEST)' -derivedDataPath "$(BUILD_OUTPUT_DIR)"
+	@set -o pipefail; $(LOGGER) log_run_xcodebuild xcodebuild test -project $(PROJECT) -scheme $(SCHEME) -configuration Debug -destination '$(DEST)' -derivedDataPath "$(BUILD_OUTPUT_DIR)"
 	@$(LOGGER) log_success "Tests complete"

--- a/scripts/log.bash
+++ b/scripts/log.bash
@@ -148,9 +148,7 @@ log_run_xcodebuild() {
     if [[ "$1" == "xcodebuild" && "$2" == "test" ]]; then
         log_run_dim xcodebuild test -quiet "${@:3}"
     else
-        local action="${@: -1}"
-        local args=("${@:1:$#-1}")
-        log_run_dim "${args[@]}" -quiet "$action"
+        log_run_dim "${@:1:$#-1}" -quiet "${@: -1}"
     fi
 }
 

--- a/scripts/log.bash
+++ b/scripts/log.bash
@@ -136,7 +136,7 @@ log_run_dim() {
 # -----------------------------------------------------------------------------------------------------------
 # Function: log_run_xcodebuild
 # Description: Run xcodebuild with dim indented output. Passes -quiet unless VERBOSE=true.
-#              Usage: set -o pipefail; log_run_xcodebuild xcodebuild ... build
+#              Usage: log_run_xcodebuild xcodebuild ... build
 # -----------------------------------------------------------------------------------------------------------
 log_run_xcodebuild() {
     if [[ "${VERBOSE:-false}" == "true" ]]; then

--- a/scripts/log.bash
+++ b/scripts/log.bash
@@ -2,7 +2,7 @@
 
 # -----------------------------------------------------------------------------------------------------------
 # Script Name: log.bash
-# Version: 1.8
+# Version: 1.9
 #
 # Description: A collection of logging utility functions for bash scripts that
 #              provide colored and formatted console output.
@@ -16,7 +16,10 @@
 #   log_success        : Green checkmark with dimmed green text for success messages
 #   log_error          : Red X symbol with dimmed red text for error messages
 #   log_warning        : Yellow triangle with dimmed yellow text for warnings
-#   log_indent          : Indent (2 spaces) and call any log function (usage: log_indent log_success "message")
+#   log_indent         : Indent (2 spaces) and call any log function (usage: log_indent log_success "message")
+#   log_pipe_dim       : Stream stdin with 2-space indent and dim styling
+#   log_run_dim        : Run a command; pipe combined stdout/stderr through log_pipe_dim
+#   log_run_xcodebuild : log_run_dim for xcodebuild (-quiet unless VERBOSE=true)
 #   log_separator      : Print a separator line across terminal width
 #   log_centered       : Print centered text
 #   log_verbose        : Log message only if VERBOSE environment variable is true
@@ -28,7 +31,7 @@
 # -----------------------------------------------------------------------------------------------------------
 # Global variables
 # -----------------------------------------------------------------------------------------------------------
-VERBOSE=false
+: "${VERBOSE:=false}"
 
 # -----------------------------------------------------------------------------------------------------------
 # Code Red ANSI color codes
@@ -108,6 +111,47 @@ log_indent() {
     shift
     printf "  "
     $log_func "$@"
+}
+
+# -----------------------------------------------------------------------------------------------------------
+# Function: log_pipe_dim
+# Description: Stream stdin with 2-space indent and dim styling (matches log_indent + log_dim).
+# -----------------------------------------------------------------------------------------------------------
+log_pipe_dim() {
+    while IFS= read -r line || [ -n "$line" ]; do
+        printf "  ${DIM}${WHITE}%s${RESET}\n" "$line"
+    done
+}
+
+# -----------------------------------------------------------------------------------------------------------
+# Function: log_run_dim
+# Description: Run a command; pipe combined stdout/stderr through log_pipe_dim.
+#              Caller should use: set -o pipefail; log_run_dim cmd ...
+# -----------------------------------------------------------------------------------------------------------
+log_run_dim() {
+    "$@" 2>&1 | log_pipe_dim
+    return "${PIPESTATUS[0]}"
+}
+
+# -----------------------------------------------------------------------------------------------------------
+# Function: log_run_xcodebuild
+# Description: Run xcodebuild with dim indented output. Passes -quiet unless VERBOSE=true.
+#              Usage: set -o pipefail; log_run_xcodebuild xcodebuild ... build
+# -----------------------------------------------------------------------------------------------------------
+log_run_xcodebuild() {
+    if [[ "${VERBOSE:-false}" == "true" ]]; then
+        log_run_dim "$@"
+        return $?
+    fi
+
+    # xcodebuild test puts the action first: xcodebuild test -project ...
+    if [[ "$1" == "xcodebuild" && "$2" == "test" ]]; then
+        log_run_dim xcodebuild test -quiet "${@:3}"
+    else
+        local action="${@: -1}"
+        local args=("${@:1:$#-1}")
+        log_run_dim "${args[@]}" -quiet "$action"
+    fi
 }
 
 # -----------------------------------------------------------------------------------------------------------

--- a/scripts/log.bash
+++ b/scripts/log.bash
@@ -125,8 +125,8 @@ log_pipe_dim() {
 
 # -----------------------------------------------------------------------------------------------------------
 # Function: log_run_dim
-# Description: Run a command; pipe combined stdout/stderr through log_pipe_dim.
-#              Caller should use: set -o pipefail; log_run_dim cmd ...
+# Description: Run a command; pipe combined stdout/stderr through log_pipe_dim. Returns the command's exit status.
+#              Usage: log_run_dim cmd ...
 # -----------------------------------------------------------------------------------------------------------
 log_run_dim() {
     "$@" 2>&1 | log_pipe_dim


### PR DESCRIPTION
## Summary
- Add `log_pipe_dim`, `log_run_dim`, and `log_run_xcodebuild` helpers to pipe tool output through indented dim styling
- Wire `build`, `build-debug`, `clean`, and `test` through the new helpers (`-quiet` by default; `VERBOSE=true` for full log)
- Fix `VERBOSE` being reset on every `source log.bash` so `VERBOSE=true make …` works
- Polish `make install` prompt indentation and use `log_warning` when install is canceled

This pull request improves the developer experience by enhancing logging and output formatting for build and test commands, and by adding new utility functions for consistent, readable logs in bash scripts. Most notably, it introduces a new logging mechanism for `xcodebuild` output, making logs easier to read by default and providing a `VERBOSE` option for more detailed output.

**Build and test output improvements:**

* All `xcodebuild` and test-related commands in the `Makefile` now use a new logger function, `log_run_xcodebuild`, which indents and dims the output by default for better readability; setting `VERBOSE=true` will show the full log. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R28-R29) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L167-R177) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L185-R191) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L400-R402)

**Logging utility enhancements:**

* The `log.bash` script introduces three new functions: `log_pipe_dim` (streams stdin with indentation and dim styling), `log_run_dim` (runs a command and pipes its output through `log_pipe_dim`), and `log_run_xcodebuild` (runs `xcodebuild` with improved output formatting and optional verbosity). [[1]](diffhunk://#diff-05a729998756d839a8b603e482dfb17de82a1d72e9c5d7fe8665ff2cda44f00aR20-R22) [[2]](diffhunk://#diff-05a729998756d839a8b603e482dfb17de82a1d72e9c5d7fe8665ff2cda44f00aR116-R156)
* The `VERBOSE` environment variable is now settable from the environment, making it easier to control logging verbosity from the command line or CI.

**Other minor improvements:**

* The `install` target in the `Makefile` now uses `log_warning` instead of `log_dim` when the install process is canceled, making the message more visible.
* The version in `log.bash` is updated to 1.9.

## Test plan
- [x] `make clean` — indented dim output, no duplicated command echo
- [x] `make build-debug` — quiet by default
- [x] `VERBOSE=true make build-debug` — full xcodebuild log (indented/dim)
- [x] `make test` — passes
- [x] `make install` — prompt indented; cancel shows warning